### PR TITLE
Fix Composer usage in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           path: |
             ~/.composer/cache
-          key: "php-${{ matrix.php-version }}-locked"
-          restore-keys: "php-${{ matrix.php-version }}-locked"
+          key: "php-${{ matrix.php-version }}-highest"
+          restore-keys: "php-${{ matrix.php-version }}-highest"
       - name: "Install highest dependencies"
         run: "composer update --no-interaction --no-progress"
       - name: "Coding Standard"
@@ -61,8 +61,8 @@ jobs:
         with:
           path: |
             ~/.composer/cache
-          key: "php-${{ matrix.php-version }}-locked"
-          restore-keys: "php-${{ matrix.php-version }}-locked"
+          key: "php-${{ matrix.php-version }}-highest"
+          restore-keys: "php-${{ matrix.php-version }}-highest"
       - name: "Install highest dependencies"
         run: "composer update --no-interaction --no-progress"
       - name: "Run Psalm"
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         dependencies:
-          - "locked"
+          - "lowest"
           - "highest"
         php-version:
           - "7.4"
@@ -96,7 +96,7 @@ jobs:
         with:
           path: |
             ~/.composer/cache
-          key: "php-${{ matrix.php-version }}-locked"
+          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
           restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
@@ -104,8 +104,8 @@ jobs:
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress --ignore-platform-reqs"
-      - name: "Install locked dependencies"
-        if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress --ignore-platform-reqs"
+#      - name: "Install locked dependencies"
+#        if: ${{ matrix.dependencies == 'locked' }}
+#        run: "composer install --no-interaction --no-progress --ignore-platform-reqs"
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --testdox --coverage-text"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,8 +32,8 @@ jobs:
             ~/.composer/cache
           key: "php-${{ matrix.php-version }}-locked"
           restore-keys: "php-${{ matrix.php-version }}-locked"
-      - name: "Install locked dependencies"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+      - name: "Install highest dependencies"
+        run: "composer update --no-interaction --no-progress"
       - name: "Coding Standard"
         run: "vendor/bin/php-cs-fixer fix --dry-run -vvv"
 
@@ -63,8 +63,8 @@ jobs:
             ~/.composer/cache
           key: "php-${{ matrix.php-version }}-locked"
           restore-keys: "php-${{ matrix.php-version }}-locked"
-      - name: "Install locked dependencies"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+      - name: "Install highest dependencies"
+        run: "composer update --no-interaction --no-progress"
       - name: "Run Psalm"
         run: "vendor/bin/psalm  --output-format=github --shepherd --stats"
 
@@ -100,12 +100,12 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest --ignore-platform-reqs"
+        run: "composer update --prefer-lowest --no-interaction --no-progress --ignore-platform-reqs"
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer update --no-interaction --no-progress --no-suggest --ignore-platform-reqs"
+        run: "composer update --no-interaction --no-progress --ignore-platform-reqs"
       - name: "Install locked dependencies"
         if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress --no-suggest --ignore-platform-reqs"
+        run: "composer install --no-interaction --no-progress --ignore-platform-reqs"
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --testdox --coverage-text"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/var-dumper": "^5.1",
         "vimeo/psalm": "^4.1",
         "amphp/http-server": "^2.1",
-        "amphp/http-server-static-content": "^1.0",
+        "amphp/http-server-static-content": "^1.0.6",
         "mnavarrocarter/amp-http-router": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.16"
     }


### PR DESCRIPTION
> You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
> No lock file found. Updating dependencies instead of installing from lock file. Use composer update over composer install if you do not have a lock file.